### PR TITLE
chore(ci): SHA-pin mutable action tag refs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,10 +21,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 


### PR DESCRIPTION
## Summary

Pin every mutable GitHub Action tag reference in this repo's workflows to the immutable commit SHA already on the magicproduct org actions allowlist. Same action version, just immutable.

## Why

magicproduct/terraform PR #15447 enforces a SHA-pinned GitHub Actions allowlist with a 48h cool-off between a new upstream tag bump and that SHA being added. Workflows here using mutable tag refs (`@v4`/`@v1`/etc.) resolve at runtime to whatever the tag currently points to. The moment a tag bump produces a SHA not yet on the allowlist, the workflow fails — even though our policy intent for that action hasn't changed. Pinning to a SHA already on the allowlist closes that race.

Reference: prior org-wide rollout discussion in magicproduct/terraform #15447. Same pattern as the merged fixes in avro, k8s-dra-driver-gpu, soci-snapshotter, multilspy, and upstream-github-runner-images.

## Test plan

- [ ] CI passes on this PR (no behavioural change expected — same SHA the tag would have resolved to)