### PR TITLE
chore(ci): use chainguard action mirrors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: chainguard-actions/actions-setup-python@fc62975567c9ddb597cf7c24edf7fd51d0187b79 # v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   lint:
-    name: Lint and test
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: chainguard-actions/actions-checkout@d1f1061cdaee56aa3a3bc3deb86b67b1db772dd6 # v6.0.2


### PR DESCRIPTION
## Summary

- Migrate executable workflow uses from `actions/setup-python` to the Chainguard mirror.
- Pin `chainguard-actions/actions-setup-python` to `fc62975567c9ddb597cf7c24edf7fd51d0187b79` (`v6.3.0`).

## Dependency

- Depends on magicproduct/terraform#16088 for the org GitHub Actions allowlist.

## Verification

- `rg --hidden -n --glob '.github/workflows/*.{yml,yaml}' --glob '.github/actions/**/action.{yml,yaml}' "uses:\s*['\"'\"]?(actions/cache|actions/setup-python|openai/codex-action)@" .` returned no matches.
- `git diff --check`
