### PR TITLE
ci: migrate workflows to self-hosted runners

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   lint:
     name: Lint and test
-    runs-on: ubuntu-latest
+    runs-on: gh-4cpu-runner-mles
     steps:
       - uses: chainguard-actions/actions-checkout@d1f1061cdaee56aa3a3bc3deb86b67b1db772dd6 # v6.0.2
         with:


### PR DESCRIPTION
## Summary
- migrate the lint/test workflow from GitHub-hosted ubuntu-latest to Magic self-hosted runners
- use gh-4cpu-runner-mles for the lightweight lint/test job

## Verification
- rg found no remaining YAML runs-on: ubuntu-latest references under .github